### PR TITLE
Show most recent slots and bags first

### DIFF
--- a/_includes/bags-content.html
+++ b/_includes/bags-content.html
@@ -1,7 +1,7 @@
 <div class="page-header" id="bags">
   <h1>Bags <small>Attend, now!</small></h1>
 </div>
-{% assign bags = site.posts | where: "archive", false %}
+{% assign bags = site.posts | where: "archive", false | sort: "start" %}
 {% for bag in bags %}
 {% if bag.event != "" %}
 <div class="featurette" id="{{ bag.title | slugify }}">

--- a/_includes/slots-content.html
+++ b/_includes/slots-content.html
@@ -1,7 +1,7 @@
 <div class="page-header" id="slots">
   <h1>Slots <small>Submit, now!</small></h1>
 </div>
-{% assign slots = site.posts | where: "archive", false | where: "event", "" %}
+{% assign slots = site.posts | where: "archive", false | where: "event", "" | sort: "start" %}
 {% for slot in slots %}
 <div class="featurette" id="{{ slot.title | slugify }}">
   {% include teaser.html bag=slot %}


### PR DESCRIPTION
This PR sorts the bags and slots according to the `start` date of the bag or slot. Therefore the most recent bag or slot would be showed first.

Any objections?
